### PR TITLE
add template key to email options interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ interface EmailOptions {
   subject: string;
   text?: string;
   html?: string;
+  template?: string;
   attachment?;
   'recipient-variables'?: {
     [email: string]: any;

--- a/src/nestjs-mailgun/services/relay/mailgun.service.ts
+++ b/src/nestjs-mailgun/services/relay/mailgun.service.ts
@@ -8,6 +8,7 @@ export interface EmailOptions {
   subject: string;
   text?: string;
   html?: string;
+  template?: string;
   attachment?;
   'recipient-variables'?: {
     [email: string]: any;


### PR DESCRIPTION
Mailgun API allows You to pass `template` as a parameter, which is used to select predefined HTML stored Mailgun.

@see https://documentation.mailgun.com/en/latest/user_manual.html?highlight=template#templates